### PR TITLE
Remove integer casting

### DIFF
--- a/lib/fixture_builder/namer.rb
+++ b/lib/fixture_builder/namer.rb
@@ -34,7 +34,7 @@ module FixtureBuilder
       # Rails 3.0 and earlier, create_fixtures returns an array of tuples
       created_fixtures.each do |fixture|
         name = fixture[0]
-        id = fixture[1]['id'].to_i
+        id = fixture[1]['id']
         table_name = fixture[1].model_class.table_name
         key = [table_name, id]
         @custom_names[key] = name
@@ -42,7 +42,7 @@ module FixtureBuilder
     end
 
     def record_name(record_hash, table_name, row_index)
-      key = [table_name, record_hash['id'].to_i]
+      key = [table_name, record_hash['id']]
       name = case
                when name_proc = @model_name_procs[table_name]
                  name_proc.call(record_hash, row_index.succ!)


### PR DESCRIPTION
We recently created a table `smart_splits` that uses UUID as the primary key. We then realized that fixture builder didn't quite work on tables with UUID for the ID.

Looking into the gem code, we found it was because the gem is/was casting the `ID` to `integer` which doesn't really work with UUID.

To solve this, we removed the casting to `integer`.